### PR TITLE
Add ShredStream sunset notice (DoubleZero Edge)

### DIFF
--- a/docs/source/lowlatencytxnfeed.md
+++ b/docs/source/lowlatencytxnfeed.md
@@ -1,5 +1,15 @@
 # ➤ Low Latency Block Updates (Shredstream)
 
+> **🚨 Jito ShredStream Deprecation Notice 🚨**
+>
+> Jito ShredStream will be deprecated in 60 days (effective **September 5, 2026**).
+>
+> To ensure uninterrupted access to Solana shreds, we recommend transitioning to **DoubleZero Edge** as the path forward. DoubleZero has put together a comprehensive transition guide specifically for our users. Eligible existing Jito ShredStream validators have access to a **90-day free trial**, so we encourage you to check it out and begin migrating soon.
+>
+> 🔗 Full details on the migration, performance benchmarks, and how to claim your free trial can be found here: [DoubleZero migration guide](TODO-INSERT-DOUBLEZERO-URL).
+>
+> If you need any support getting set up, head over to the **#jito-shredstream** channel in the DoubleZero Discord.
+
 Jito's ShredStream service delivers the lowest latency shreds from leaders on the Solana network, optimizing performance for high-frequency trading, validation, and RPC operations. ShredStream ensures minimal latency for receiving shreds, which can save hundreds of milliseconds during trading on Solana—a critical advantage in high-frequency trading environments. Additionally, it provides a redundant shred path for servers in remote locations, enhancing reliability and performance for users operating in less connected regions. This makes ShredStream particularly valuable for traders, validators, and node operators who require the fastest and most reliable data to maintain a competitive edge.
 
 ## Shreds

--- a/docs/source/lowlatencytxnfeed.md
+++ b/docs/source/lowlatencytxnfeed.md
@@ -2,7 +2,7 @@
 
 > **🚨 Jito ShredStream Sunset Notice 🚨**
 >
-> We are officially deprecating Jito ShredStream, effective immediately. The service will be completely shut down in 60 days (**September 5, 2026**).
+> We are beginning the process of deprecating Jito ShredStream. The service will be completely shut down in 60 days (**September 5, 2026**), meaning you won't have access to Jito ShredStream at that time. You should begin the process of migrating off of Jito ShredStream.
 >
 > To ensure uninterrupted access to Solana shreds, we highly recommend transitioning to **DoubleZero Edge** before the shutdown date. DoubleZero has put together a comprehensive transition guide for our users, which includes details on how eligible existing ShredStream validators can claim a **90-day free trial**. We encourage you to review it and begin migrating as soon as possible.
 >

--- a/docs/source/lowlatencytxnfeed.md
+++ b/docs/source/lowlatencytxnfeed.md
@@ -1,14 +1,14 @@
 # ➤ Low Latency Block Updates (Shredstream)
 
-> **🚨 Jito ShredStream Deprecation Notice 🚨**
+> **🚨 Jito ShredStream Sunset Notice 🚨**
 >
-> Jito ShredStream will be deprecated in 60 days (effective **September 5, 2026**).
+> We are officially deprecating Jito ShredStream, effective immediately. The service will be completely shut down in 60 days (**September 5, 2026**).
 >
-> To ensure uninterrupted access to Solana shreds, we recommend transitioning to **DoubleZero Edge** as the path forward. DoubleZero has put together a comprehensive transition guide specifically for our users. Eligible existing Jito ShredStream validators have access to a **90-day free trial**, so we encourage you to check it out and begin migrating soon.
+> To ensure uninterrupted access to Solana shreds, we highly recommend transitioning to **DoubleZero Edge** before the shutdown date. DoubleZero has put together a comprehensive transition guide for our users, which includes details on how eligible existing ShredStream validators can claim a **90-day free trial**. We encourage you to review it and begin migrating as soon as possible.
 >
-> 🔗 Full details on the migration, performance benchmarks, and how to claim your free trial can be found here: [DoubleZero migration guide](TODO-INSERT-DOUBLEZERO-URL).
+> 🔗 Full details on the migration, performance benchmarks, and how to get set up can be found here: [DoubleZero migration guide](TODO-INSERT-DOUBLEZERO-URL).
 >
-> If you need any support getting set up, head over to the **#jito-shredstream** channel in the DoubleZero Discord.
+> If you need any support during the transition, head over to the [**#jito-shredstream**](TODO-INSERT-DISCORD-CHANNEL-URL) channel in the DoubleZero Discord.
 
 Jito's ShredStream service delivers the lowest latency shreds from leaders on the Solana network, optimizing performance for high-frequency trading, validation, and RPC operations. ShredStream ensures minimal latency for receiving shreds, which can save hundreds of milliseconds during trading on Solana—a critical advantage in high-frequency trading environments. Additionally, it provides a redundant shred path for servers in remote locations, enhancing reliability and performance for users operating in less connected regions. This makes ShredStream particularly valuable for traders, validators, and node operators who require the fastest and most reliable data to maintain a competitive edge.
 

--- a/docs/source/lowlatencytxnfeed.md
+++ b/docs/source/lowlatencytxnfeed.md
@@ -4,11 +4,11 @@
 >
 > We are beginning the process of deprecating Jito ShredStream. The service will be completely shut down in 60 days (**September 5, 2026**), meaning you won't have access to Jito ShredStream at that time. You should begin the process of migrating off of Jito ShredStream.
 >
-> To ensure uninterrupted access to Solana shreds, we highly recommend transitioning to **DoubleZero Edge** before the shutdown date. DoubleZero has put together a comprehensive transition guide for our users, which includes details on how eligible existing ShredStream validators can claim a **90-day free trial**. We encourage you to review it and begin migrating as soon as possible.
+> To ensure uninterrupted access to Solana shreds, we highly recommend transitioning to **DoubleZero Edge** before the shutdown date. DoubleZero has put together a comprehensive transition guide for our users, which includes details on how users can access a free trial. We encourage you to review it and begin migrating as soon as possible.
 >
-> 🔗 Full details on the migration, performance benchmarks, and how to get set up can be found here: [DoubleZero migration guide](TODO-INSERT-DOUBLEZERO-URL).
+> 🔗 Full details on the migration, performance benchmarks, and how to get set up can be found here: [DoubleZero migration guide](http://doublezero.xyz/jito-shredstream).
 >
-> If you need any support during the transition, head over to the [**#jito-shredstream**](TODO-INSERT-DISCORD-CHANNEL-URL) channel in the DoubleZero Discord.
+> If you need any support during the transition, head over to the [**#jito-shredstream**](https://discord.com/invite/doublezerotech) channel in the DoubleZero Discord.
 
 Jito's ShredStream service delivers the lowest latency shreds from leaders on the Solana network, optimizing performance for high-frequency trading, validation, and RPC operations. ShredStream ensures minimal latency for receiving shreds, which can save hundreds of milliseconds during trading on Solana—a critical advantage in high-frequency trading environments. Additionally, it provides a redundant shred path for servers in remote locations, enhancing reliability and performance for users operating in less connected regions. This makes ShredStream particularly valuable for traders, validators, and node operators who require the fastest and most reliable data to maintain a competitive edge.
 

--- a/docs/source/lowlatencytxnfeed.md
+++ b/docs/source/lowlatencytxnfeed.md
@@ -6,7 +6,7 @@
 >
 > To ensure uninterrupted access to Solana shreds, we highly recommend transitioning to **DoubleZero Edge** before the shutdown date. DoubleZero has put together a comprehensive transition guide for our users, which includes details on how users can access a free trial. We encourage you to review it and begin migrating as soon as possible.
 >
-> 🔗 Full details on the migration, performance benchmarks, and how to get set up can be found here: [DoubleZero migration guide](http://doublezero.xyz/jito-shredstream).
+> 🔗 Full details on the migration, performance benchmarks, and how to get set up can be found here: [DoubleZero migration guide](https://doublezero.xyz/jito-shredstream).
 >
 > If you need any support during the transition, head over to the [**#jito-shredstream**](https://discord.com/invite/doublezerotech) channel in the DoubleZero Discord.
 


### PR DESCRIPTION
## Summary

Adds a sunset notice to the top of the **Low Latency Block Updates (Shredstream)** page announcing that Jito ShredStream is being deprecated, with full shutdown in 60 days (**September 5, 2026**), directing users to **DoubleZero Edge** for migration.

The notice is placed as a callout immediately below the H1, before the intro paragraph. Wording finalized per legal review; migration guide and Discord links included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)