### PR TITLE
Point tip dashboard link to explorer.jito.wtf

### DIFF
--- a/docs/source/lowlatencytxnsend.md
+++ b/docs/source/lowlatencytxnsend.md
@@ -627,7 +627,7 @@ wscat -c wss://bundles.jito.wtf/api/v1/bundles/tip_stream
 ```
 
 #### Tip Dashboard
-To view dashboard please [click here](https://jito-labs.metabaseapp.com/public/dashboard/016d4d60-e168-4a8f-93c7-4cd5ec6c7c8d) .
+To view dashboard please [click here](https://explorer.jito.wtf/tip-floor) .
 
 ## Rate Limits
 


### PR DESCRIPTION
Updates the Tip Dashboard link in `docs/source/lowlatencytxnsend.md` from the old Metabase public dashboard to the Jito Explorer tip floor page.

- From: `https://jito-labs.metabaseapp.com/public/dashboard/016d4d60-e168-4a8f-93c7-4cd5ec6c7c8d`
- To: `https://explorer.jito.wtf/tip-floor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)